### PR TITLE
install interworx-cli task earlier in playbook

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,11 @@
   failed_when: iworx_install_result.rc != 0
   when: iw_is_inst.rc !=0
 
+- name: Install Interworx CLI
+  package:
+    name="interworx-cli"
+    state={{ iw_cli_pkg_state }}
+
 - name: Seed /etc/hosts With Correct License IP
   lineinfile:
     path="/etc/hosts"
@@ -87,11 +92,6 @@
     group="root"
     state="link"
   when: iw_symlink_base_php
-
-- name: Install Interworx CLI
-  package:
-    name="interworx-cli"
-    state={{ iw_cli_pkg_state }}
 
 - name: Accept Interworx EULA
   ini_file:


### PR DESCRIPTION
The `interworx-cli` package mysteriously gets installed sometime between starting the goiworx.php script, and the task to start removing the base PHP versions. Because this happens outside of an ansible task, it ends up causing periodic failures when yum is being held open by its installation, and the task to start removing PHP packages begins.

Since no team seems to be able to see any reference to why this is getting installed when it is, the (hopeful) solution for now is to just install the package earlier in the process, since ultimately we *do* want it installed, we just need it installed in a trackable and predictable way.